### PR TITLE
Locate Wayland socket in dedicated directory

### DIFF
--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -12,6 +12,7 @@ fi
 export MIR_CLIENT_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/client-platform
 export MIR_SERVER_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/server-platform
 
-mkdir -p $XDG_RUNTIME_DIR # make sure it exists
+mkdir -p $SNAP_DATA/wayland # make sure it exists
 
-exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket
+exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket \
+        --wayland-socket-name ../../../../$SNAP_DATA/wayland/wayland-0

--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -12,7 +12,7 @@ fi
 export MIR_CLIENT_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/client-platform
 export MIR_SERVER_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/server-platform
 
-mkdir -p $SNAP_DATA/wayland # make sure it exists
+export XDG_RUNTIME_DIR=$SNAP_DATA/wayland
+mkdir -p $XDG_RUNTIME_DIR # make sure it exists
 
-exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket \
-        --wayland-socket-name ../../../../$SNAP_DATA/wayland/wayland-0
+exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket

--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -12,7 +12,8 @@ fi
 export MIR_CLIENT_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/client-platform
 export MIR_SERVER_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/server-platform
 
-export XDG_RUNTIME_DIR=$SNAP_DATA/wayland
-mkdir -p $XDG_RUNTIME_DIR # make sure it exists
+export XDG_RUNTIME_DIR=$SNAP_DATA
+mkdir -p $XDG_RUNTIME_DIR/wayland # destination dir for wayland socket
 
-exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket
+exec ${SNAP}/usr/bin/miral-kiosk --vt 1 --arw-file --file /run/mir_socket \
+        --wayland-socket-name="wayland/wayland-0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ slots:
     interface: content
     content: wayland-socket-dir
     write:
-      - $SNAP_DATA/wayland #really should be $XDG_RUNTIME_DIR, should patch snapd to enable that
+      - $SNAP_DATA/wayland
 
 apps:
   mir-kiosk:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,8 @@ slots:
   wayland-socket-dir:
     interface: content
     content: wayland-socket-dir
-    write: [ $SNAP_DATA/wayland ]
+    write:
+      - $SNAP_DATA/wayland #really should be $XDG_RUNTIME_DIR, should patch snapd to enable that
 
 apps:
   mir-kiosk:
@@ -28,8 +29,6 @@ apps:
     plugs:
       - opengl
     environment:
-      # Share the wayland sockets via content interface, so place in dedicated directory
-      XDG_RUNTIME_DIR: $SNAP_DATA/wayland
       XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
       XCURSOR_PATH:    $SNAP/icons
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,7 @@ slots:
   wayland-socket-dir:
     interface: content
     content: wayland-socket-dir
-    write:
-      - $SNAP_DATA/wayland
+    write: [ $SNAP_DATA/wayland ]
 
 apps:
   mir-kiosk:


### PR DESCRIPTION
Locate Wayland socket in a dedicated directory, minimises chance of other files appearing in $XDG_RUNTIME_DIR being accidentally shared over the content interface.