### PR TITLE
Set up a .config on install and use it

### DIFF
--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -14,4 +14,4 @@ export MIR_SERVER_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/server-platform
 
 mkdir -p $XDG_RUNTIME_DIR # make sure it exists
 
-exec ${SNAP}/usr/bin/miral-kiosk $*
+exec ${SNAP}/usr/bin/miral-kiosk "$@"

--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -14,4 +14,4 @@ export MIR_SERVER_PLATFORM_PATH=${SNAP}/usr/lib/${ARCH}/mir/server-platform
 
 mkdir -p $XDG_RUNTIME_DIR # make sure it exists
 
-exec ${SNAP}/usr/bin/miral-kiosk --console-provider=vt --vt 4 --arw-file --file /run/mir_socket
+exec ${SNAP}/usr/bin/miral-kiosk $*

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,11 +1,18 @@
 #!/bin/bash
 
+# Ensure we have a config file with the fixed options
+if [ ! -e "$SNAP_COMMON/miral-kiosk.config" ]; then
+cat <<EOT > "$SNAP_COMMON/miral-kiosk.config"
+arw-file=
+file=/run/mir_socket
+console-provider=vt
+EOT
+fi
+
 # display-layout
 display_layout=$(snapctl get display-layout)
 if [ -n "${display_layout}" ]; then
-  if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
-    sed --in-place=.save '/^display-layout/d' $SNAP_COMMON/miral-kiosk.config
-  fi
+  sed --in-place=.save '/^display-layout/d' $SNAP_COMMON/miral-kiosk.config
   echo display-layout=${display_layout} >> $SNAP_COMMON/miral-kiosk.config
   snapctl restart $SNAP_NAME
 fi
@@ -13,9 +20,12 @@ fi
 # vt
 vt=$(snapctl get vt)
 if [ -n "${vt}" ]; then
-  if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
-    sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+  if [ -n "${vt//[0-9]}" ] || [ ! -e "/dev/tty$vt" ]; then
+    echo "ERROR: '$vt' is not a valid VT"
+    exit 1
   fi
+
+  sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
   echo vt=${vt} >> $SNAP_COMMON/miral-kiosk.config
   snapctl restart $SNAP_NAME
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+# display-layout
 display_layout=$(snapctl get display-layout)
 if [ -n "${display_layout}" ]; then
   if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
     sed --in-place=.save '/^display-layout/d' $SNAP_COMMON/miral-kiosk.config
   fi
   echo display-layout=${display_layout} >> $SNAP_COMMON/miral-kiosk.config
+  snapctl restart $SNAP_NAME
+fi
+
+# vt
+vt=$(snapctl get vt)
+if [ -n "${vt}" ]; then
+  if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
+    sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+  fi
+  echo vt=${vt} >> $SNAP_COMMON/miral-kiosk.config
   snapctl restart $SNAP_NAME
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+changes=0
+
 # Ensure we have a config file with the fixed options
 if [ ! -e "$SNAP_COMMON/miral-kiosk.config" ]; then
 cat <<EOT > "$SNAP_COMMON/miral-kiosk.config"
@@ -7,14 +9,21 @@ arw-file=
 file=/run/mir_socket
 console-provider=vt
 EOT
+let changes+=1
 fi
 
 # display-layout
 display_layout=$(snapctl get display-layout)
 if [ -n "${display_layout}" ]; then
-  sed --in-place=.save '/^display-layout/d' $SNAP_COMMON/miral-kiosk.config
-  echo display-layout=${display_layout} >> $SNAP_COMMON/miral-kiosk.config
-  snapctl restart $SNAP_NAME
+  if [ "display-layout=${display_layout}" != "$(grep \^display-layout= $SNAP_COMMON/miral-kiosk.config)" ]; then
+    if [ changes -gt 0 ]; then
+      sed '/^display-layout=/d' $SNAP_COMMON/miral-kiosk.config
+    else
+      sed --in-place=.save '/^display-layout=/d' $SNAP_COMMON/miral-kiosk.config
+    fi
+    echo display-layout=${display_layout} >> $SNAP_COMMON/miral-kiosk.config
+    let changes+=1
+  fi
 fi
 
 # vt
@@ -25,7 +34,17 @@ if [ -n "${vt}" ]; then
     exit 1
   fi
 
-  sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
-  echo vt=${vt} >> $SNAP_COMMON/miral-kiosk.config
+  if [ "vt=${vt}" != "$(grep vt= $SNAP_COMMON/miral-kiosk.config)" ]; then
+    if [ changes -gt 0 ]; then
+      sed '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+    else
+      sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+    fi
+    echo vt=${vt} >> $SNAP_COMMON/miral-kiosk.config
+    let changes+=1
+  fi
+fi
+
+if [ $changes -gt 0 ]; then
   snapctl restart $SNAP_NAME
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -3,8 +3,8 @@
 changes=0
 
 # Ensure we have a config file with the fixed options
-if [ ! -e "$SNAP_COMMON/miral-kiosk.config" ]; then
-cat <<EOT > "$SNAP_COMMON/miral-kiosk.config"
+if [ ! -e "$SNAP_DATA/miral-kiosk.config" ]; then
+cat <<EOT > "$SNAP_DATA/miral-kiosk.config"
 arw-file=
 file=/run/mir_socket
 console-provider=vt
@@ -15,25 +15,25 @@ fi
 # display-layout
 display_layout=$(snapctl get display-layout)
 if [ -n "${display_layout}" ]; then
-  if [ -e "$SNAP_COMMON/miral-kiosk.display" ]; then
-    if [ -z "$(grep "^  ${display_layout}:" "$SNAP_COMMON/miral-kiosk.display")" ]; then
-      echo "ERROR: '$display_layout' is not a layout in $SNAP_COMMON/miral-kiosk.display"
+  if [ -e "$SNAP_DATA/miral-kiosk.display" ]; then
+    if [ -z "$(grep "^  ${display_layout}:" "$SNAP_DATA/miral-kiosk.display")" ]; then
+      echo "ERROR: '$display_layout' is not a layout in $SNAP_DATA/miral-kiosk.display"
       exit 1
     fi
   else
     if [ "${display_layout}" != "default" ]; then
-      echo "ERROR: '$display_layout' is not a layout in $SNAP_COMMON/miral-kiosk.display"
+      echo "ERROR: '$display_layout' is not a layout in $SNAP_DATA/miral-kiosk.display"
       exit 1
     fi
   fi
 
-  if [ "display-layout=${display_layout}" != "$(grep \^display-layout= $SNAP_COMMON/miral-kiosk.config)" ]; then
+  if [ "display-layout=${display_layout}" != "$(grep \^display-layout= $SNAP_DATA/miral-kiosk.config)" ]; then
     if [ changes -gt 0 ]; then
-      sed '/^display-layout=/d' $SNAP_COMMON/miral-kiosk.config
+      sed '/^display-layout=/d' $SNAP_DATA/miral-kiosk.config
     else
-      sed --in-place=.save '/^display-layout=/d' $SNAP_COMMON/miral-kiosk.config
+      sed --in-place=.save '/^display-layout=/d' $SNAP_DATA/miral-kiosk.config
     fi
-    echo display-layout=${display_layout} >> $SNAP_COMMON/miral-kiosk.config
+    echo display-layout=${display_layout} >> $SNAP_DATA/miral-kiosk.config
     let changes+=1
   fi
 fi
@@ -46,13 +46,13 @@ if [ -n "${vt}" ]; then
     exit 1
   fi
 
-  if [ "vt=${vt}" != "$(grep vt= $SNAP_COMMON/miral-kiosk.config)" ]; then
+  if [ "vt=${vt}" != "$(grep vt= $SNAP_DATA/miral-kiosk.config)" ]; then
     if [ changes -gt 0 ]; then
-      sed '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+      sed '/^vt/d' $SNAP_DATA/miral-kiosk.config
     else
-      sed --in-place=.save '/^vt/d' $SNAP_COMMON/miral-kiosk.config
+      sed --in-place=.save '/^vt/d' $SNAP_DATA/miral-kiosk.config
     fi
-    echo vt=${vt} >> $SNAP_COMMON/miral-kiosk.config
+    echo vt=${vt} >> $SNAP_DATA/miral-kiosk.config
     let changes+=1
   fi
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,6 +15,18 @@ fi
 # display-layout
 display_layout=$(snapctl get display-layout)
 if [ -n "${display_layout}" ]; then
+  if [ -e "$SNAP_COMMON/miral-kiosk.display" ]; then
+    if [ -z "$(grep "^  ${display_layout}:" "$SNAP_COMMON/miral-kiosk.display")" ]; then
+      echo "ERROR: '$display_layout' is not a layout in $SNAP_COMMON/miral-kiosk.display"
+      exit 1
+    fi
+  else
+    if [ "${display_layout}" != "default" ]; then
+      echo "ERROR: '$display_layout' is not a layout in $SNAP_COMMON/miral-kiosk.display"
+      exit 1
+    fi
+  fi
+
   if [ "display-layout=${display_layout}" != "$(grep \^display-layout= $SNAP_COMMON/miral-kiosk.config)" ]; then
     if [ changes -gt 0 ]; then
       sed '/^display-layout=/d' $SNAP_COMMON/miral-kiosk.config

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-cat <<EOT >> "$SNAP_COMMON/miral-kiosk.config"
-console-provider=vt
-vt=4
-arw-file=
-file=/run/mir_socket
-EOT
+snapctl set display-layout=default vt=4

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
-  sed --in-place=.save '/^\(console-provider\|vt\|arw-file\|file\)=.*/d' $SNAP_COMMON/miral-kiosk.config
-fi
-
 cat <<EOT >> "$SNAP_COMMON/miral-kiosk.config"
 console-provider=vt
 vt=4

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -e "$SNAP_COMMON/miral-kiosk.config" ]; then
+  sed --in-place=.save '/^\(console-provider\|vt\|arw-file\|file\)=.*/d' $SNAP_COMMON/miral-kiosk.config
+fi
+
+cat <<EOT >> "$SNAP_COMMON/miral-kiosk.config"
+console-provider=vt
+vt=4
+arw-file=
+file=/run/mir_socket
+EOT

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ apps:
       # Share the wayland sockets via content interface, so place in dedicated directory
       XDG_RUNTIME_DIR: $SNAP_DATA/wayland
       XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
-      XDG_CONFIG_HOME: $SNAP_COMMON
+      XDG_CONFIG_HOME: $SNAP_DATA
       XCURSOR_PATH:    $SNAP/icons
 
 parts:


### PR DESCRIPTION
This won't cause errors if options are set that Mir doesn't recognise and allows reconfiguration of the snap.