### PR TITLE
Workaround for Mir not starting if the gadget snap sets 'vt.handoff'

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,3 +1,12 @@
 #!/bin/sh
+set -e
 
-snapctl set display-layout=default vt=4 cursor=auto
+# If 'vt.handoff' is set, Mir only starts first time on the default VT. (#779)
+# Until we understand and fix properly, set the config the way that works.
+vt=$(sed -n 's/.*vt.handoff=\([^ ]*\).*/\1/p' /proc/cmdline)
+if [ -z "$vt" ]
+then vt=4
+else vt=0
+fi
+
+snapctl set display-layout=default vt=$vt cursor=auto


### PR DESCRIPTION
Workaround for Mir not starting if the gadget snap sets 'vt.handoff'. Workaround for https://github.com/MirServer/mir/issues/779