### PR TITLE
Rework startup & configuration

### DIFF
--- a/glue/bin/run-daemon
+++ b/glue/bin/run-daemon
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+if [ "$(snapctl get daemon)" = "true" ]; then
+    exec "$@"
+fi

--- a/glue/bin/run-miral
+++ b/glue/bin/run-miral
@@ -1,4 +1,6 @@
 #!/bin/bash
-[ ! -d "$XDG_RUNTIME_DIR" ] && mkdir $XDG_RUNTIME_DIR -m 700
+
+export XDG_RUNTIME_DIR=$(dirname $XDG_RUNTIME_DIR)
+mkdir -p $XDG_RUNTIME_DIR -m 700
 
 exec ${SNAP}/usr/bin/miral-kiosk "$@"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -29,11 +29,7 @@ fi
 
 daemon=$(snapctl get daemon)
 if [ "$daemon" = "" ]
-then
-  if grep -q snap_core= /proc/cmdline
-  then daemon=true
-  else daemon=false
-  fi
+then daemon=true
 fi
 
 snapctl set display-layout=$display_layout vt=$vt cursor=$cursor daemon=$daemon

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,31 +4,44 @@ summary: A minimal Mir based shell for kiosk type applications
 description: A minimal Mir based shell for kiosk type applications
 confinement: strict
 base: core18
+license: GPL-3.0 OR GPL-2.0
 
 environment:
-  #  # XDG config
-  XDG_CONFIG_HOME: $SNAP_DATA
-  XDG_RUNTIME_DIR: /run/user/0 # hardcoding as root for now
   # Prep for Mir
   MIR_CLIENT_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/client-platform
   MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform
+  # Prep EGL
+  __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
+  LIBGL_DRIVERS_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+  LIBVA_DRIVERS_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
 
-passthrough:
-  layout:
-    /usr/share:
-      bind: $SNAP/usr/share
-    /etc/glvnd:
-      bind: $SNAP/etc/glvnd
+layout:
+  /usr/share:
+    bind: $SNAP/usr/share
+  /etc/glvnd:
+    bind: $SNAP/etc/glvnd
 
 apps:
   mir-kiosk:
     command: bin/run-miral
-    daemon: simple
-    slots:
-      - mir
-      - wayland
     plugs:
-      - opengl
+      - x11
+    environment:
+      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio:${SNAP}/usr/lib/libreoffice/program/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/samba
+
+  daemon:
+    command: bin/run-daemon $SNAP/bin/run-miral
+    daemon: simple
+    environment:
+      # XDG config
+      XDG_CONFIG_HOME: $SNAP_DATA
+
+slots:
+  mir:
+  wayland:
+
+plugs:
+  opengl:
 
 parts:
   ppa-mir:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,27 @@ parts:
     stage-packages:
       - mir-graphics-drivers-desktop
       - mir-demos
+    prime:
+      - -lib/udev
+      - -usr/doc
+      - -usr/doc-base
+      - -usr/share/applications
+      - -usr/share/apport
+      - -usr/share/bug
+      - -usr/share/doc
+      - -usr/share/doc-base
+      - -usr/share/icons
+      - -usr/share/libdrm
+      - -usr/share/libwacom
+      - -usr/share/lintian
+      - -usr/share/man
+      - -usr/share/pkgconfig
+      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform/server-mesa-x11.so.*
+      - -usr/bin/miral-app
+      - -usr/bin/miral-desktop
+      - -usr/bin/miral-run
+      - -usr/bin/miral-shell
+      - -usr/bin/miral-xrun
 
   icons:
     plugin: nil


### PR DESCRIPTION
Rework startup & configuration

This brings better behaviour when installed on a desktop system:

  o daemon defaults to false
  o can be run on an X11 desktop (including, with devmode, as root)

This makes testing kiosk snaps a lot easier.