### PR TITLE
Drop the mir interface slot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,6 @@ apps:
       XDG_CONFIG_HOME: $SNAP_DATA
 
 slots:
-  mir:
   wayland:
 
 plugs:


### PR DESCRIPTION
Drop the mir interface slot. It isn't needed for Mir 1.5 on.