### PR TITLE
Add show-splash to configure hook

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -131,3 +131,23 @@ fi
 if [ $(($config_changes+$display_changes)) -gt 0 ]; then
   snapctl restart $SNAP_NAME
 fi
+
+# show-splash 
+show-splash=$(snapctl get show-splash)
+if [ -n "${show-splash}" ]; then
+  if [[ ! "${show-splash}" =~ ^(true|false)$ ]]; then
+    echo "ERROR: '$show-splash' is not a valid cursor option (true|false)"
+    exit 1
+  fi
+
+  if [ "show-splash=${show-splash}" != "$(grep show-splash= ${miral_kiosk_config})" ]; then
+    if [ $config_changes -gt 0 ]; then
+      sed '/^show-splash/d' ${miral_kiosk_config}
+    else
+      sed --in-place=.save '/^show-splash/d' ${miral_kiosk_config}
+    fi
+    echo show-splash=${show-splash} >> ${miral_kiosk_config}
+    let config_changes+=1
+  fi
+fi
+

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -133,20 +133,20 @@ if [ $(($config_changes+$display_changes)) -gt 0 ]; then
 fi
 
 # show-splash 
-show-splash=$(snapctl get show-splash)
-if [ -n "${show-splash}" ]; then
-  if [[ ! "${show-splash}" =~ ^(true|false)$ ]]; then
-    echo "ERROR: '$show-splash' is not a valid cursor option (true|false)"
+showsplash=$(snapctl get show-splash)
+if [ -n "${showsplash}" ]; then
+  if [[ ! "${showsplash}" =~ ^(true|false)$ ]]; then
+    echo "ERROR: '$showsplash' is not a valid cursor option (true|false)"
     exit 1
   fi
 
-  if [ "show-splash=${show-splash}" != "$(grep show-splash= ${miral_kiosk_config})" ]; then
+  if [ "show-splash=${showsplash}" != "$(grep show-splash= ${miral_kiosk_config})" ]; then
     if [ $config_changes -gt 0 ]; then
       sed '/^show-splash/d' ${miral_kiosk_config}
     else
       sed --in-place=.save '/^show-splash/d' ${miral_kiosk_config}
     fi
-    echo show-splash=${show-splash} >> ${miral_kiosk_config}
+    echo show-splash=${showsplash} >> ${miral_kiosk_config}
     let config_changes+=1
   fi
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -37,4 +37,9 @@ then
   fi
 fi
 
-snapctl set display-layout=$display_layout vt=$vt cursor=$cursor daemon=$daemon
+show_splash=$(snapctl get show-splash)
+if [ "$show_splash" = "" ]
+then show_splash=true
+fi
+
+snapctl set display-layout=$display_layout vt=$vt cursor=$cursor daemon=$daemon show-splash=$show_splash


### PR DESCRIPTION
With this, the following suppresses splash display on mir-kiosk.daemon restart:
$ snap set mir-kiosk show-splash=false

And this enables splash display on restart:
$ snap set mir-kiosk show-splash=true

