### PR TITLE
Safer startup logic

### DIFF
--- a/glue/bin/run-daemon
+++ b/glue/bin/run-daemon
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-nohup "$@"
+exec nohup "$@"

--- a/glue/bin/run-daemon
+++ b/glue/bin/run-daemon
@@ -1,6 +1,4 @@
 #!/bin/sh
 set -e
 
-if [ "$(snapctl get daemon)" = "true" ]; then
-    exec nohup "$@"
-fi
+nohup "$@"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -151,10 +151,8 @@ if [ "$(snapctl get daemon)" = "true" ]; then
   if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
     snapctl start --enable $SNAP_NAME.daemon 2>&1 || true
   elif [ $(($config_changes+$display_changes)) -gt 0 ]; then
-    snapctl restart $SNAP_NAME
+    snapctl restart $SNAP_NAME || true
   fi
 else
-  if snapctl services ${SNAP_NAME}.daemon | grep -q enabled; then
-    snapctl stop --disable $SNAP_NAME.daemon 2>&1 || true
-  fi
+  snapctl stop --disable $SNAP_NAME.daemon 2>&1 || true
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -150,13 +150,11 @@ fi
 if [ "$(snapctl get daemon)" = "true" ]; then
   if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
     snapctl start --enable $SNAP_NAME.daemon 2>&1 || true
+  elif [ $(($config_changes+$display_changes)) -gt 0 ]; then
+    snapctl restart $SNAP_NAME
   fi
 else
   if snapctl services ${SNAP_NAME}.daemon | grep -q enabled; then
     snapctl stop --disable $SNAP_NAME.daemon 2>&1 || true
   fi
-fi
-
-if [ $(($config_changes+$display_changes)) -gt 0 ]; then
-  snapctl restart $SNAP_NAME
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -128,10 +128,6 @@ if [ -n "${cursor}" ]; then
   fi
 fi
 
-if [ $(($config_changes+$display_changes)) -gt 0 ]; then
-  snapctl restart $SNAP_NAME
-fi
-
 # show-splash 
 showsplash=$(snapctl get show-splash)
 if [ -n "${showsplash}" ]; then
@@ -151,3 +147,16 @@ if [ -n "${showsplash}" ]; then
   fi
 fi
 
+if [ "$(snapctl get daemon)" = "true" ]; then
+  if snapctl services ${SNAP_NAME}.daemon | grep -q inactive; then
+    snapctl start --enable $SNAP_NAME.daemon 2>&1 || true
+  fi
+else
+  if snapctl services ${SNAP_NAME}.daemon | grep -q enabled; then
+    snapctl stop --disable $SNAP_NAME.daemon 2>&1 || true
+  fi
+fi
+
+if [ $(($config_changes+$display_changes)) -gt 0 ]; then
+  snapctl restart $SNAP_NAME
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,7 +2,7 @@
 set -e
 
 # we install with the daemon disabled, the configure hook
-# will start it if appropriate
+# will start and enable it if appropriate
 snapctl stop --disable $SNAP_NAME.daemon
 
 display_layout=$(snapctl get display-layout)

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# we install with the daemon disabled, the configure hook
+# will start it if appropriate
+snapctl stop --disable $SNAP_NAME.daemon
+
 display_layout=$(snapctl get display-layout)
 if [ "$display_layout" = "" ]
 then display_layout=default

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -2,7 +2,7 @@
 set -e
 
 # we install with the daemon disabled, the configure hook
-# will start it if appropriate
+# will start and enable it if appropriate
 snapctl stop --disable $SNAP_NAME.daemon
 
 display_layout=$(snapctl get display-layout)

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# we install with the daemon disabled, the configure hook
+# will start it if appropriate
+snapctl stop --disable $SNAP_NAME.daemon
+
 display_layout=$(snapctl get display-layout)
 if [ "$display_layout" = "" ]
 then display_layout=default


### PR DESCRIPTION
Don't use snapctl on `run-daemon`, it is racy and can fail some of the time on some systems.

See https://forum.snapcraft.io/t/scummvm-snap-failing-to-install-on-rpi-4/21394/59