### PR TITLE
Set daemon restart delay time to 3 seconds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ apps:
   daemon:
     command: bin/run-daemon $SNAP/bin/run-miral
     daemon: simple
+    restart-delay: 3s
     environment:
       # XDG config
       XDG_CONFIG_HOME: $SNAP_DATA


### PR DESCRIPTION
Adding a restart delay of 3 seconds will prevent systemd stopping the service after trying to start, 5 attempts in quick succession.

As snap doesn't expose all systemd unit params, restart delay is the most effect way to implement this.

By default, these are the systemd unit rules:
```
StartLimitIntervalSec=10s
StartLimitBurst=5
```

Which is from these from these settings, commented to default values below:
```
/etc/systemd/system.conf:#DefaultStartLimitIntervalSec=10s
/etc/systemd/system.conf:#DefaultStartLimitBurst=5
/etc/systemd/user.conf:#DefaultStartLimitIntervalSec=10s
/etc/systemd/user.conf:#DefaultStartLimitBurst=5
```
